### PR TITLE
The latest webkit supports ES6 maps, but doesn’t seem to pass the third ...

### DIFF
--- a/lib/MultiMap.js
+++ b/lib/MultiMap.js
@@ -39,6 +39,11 @@ MultiMap.prototype = {
 		}
 	},
 	'filterAll': function(filterFunction) {
+
+		//TODO: The following line can be removed and instead a third 'map' parameter 
+		// can be added to the forEach callback once the following webkit bug is resovled
+		// https://bugs.webkit.org/show_bug.cgi?id=138563
+
 		var map = this._map;
 		this._map.forEach(function(values, key) {
 			var newValues = values.filter(filterFunction);


### PR DESCRIPTION
...‘map’ parameter back to a forEach function.
